### PR TITLE
Support custom ca-certificates in self-host chart

### DIFF
--- a/charts/self-host/templates/admin.yaml
+++ b/charts/self-host/templates/admin.yaml
@@ -79,6 +79,10 @@ spec:
           mountPath: /etc/bitwarden/logs
           subPath: admin
         {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          mountPath: /etc/bitwarden/ca-certificates
+        {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
@@ -97,6 +101,10 @@ spec:
         - name: applogs
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          persistentVolumeClaim:
+            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline

--- a/charts/self-host/templates/admin.yaml
+++ b/charts/self-host/templates/admin.yaml
@@ -101,6 +101,7 @@ spec:
         - name: applogs
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
+        {{- end }}
         {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
           persistentVolumeClaim:

--- a/charts/self-host/templates/admin.yaml
+++ b/charts/self-host/templates/admin.yaml
@@ -79,9 +79,9 @@ spec:
           mountPath: /etc/bitwarden/logs
           subPath: admin
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
-          mountPath: /etc/bitwarden/ca-certificates
+          mountPath: /etc/bitwarden.ca_certificates
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
@@ -101,10 +101,10 @@ spec:
         - name: applogs
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
           persistentVolumeClaim:
-            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
+            claimName: {{ default ( include "bitwarden.ca_certificates" . ) .Values.volume.ca_certificates.existingClaim }}
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline

--- a/charts/self-host/templates/api.yaml
+++ b/charts/self-host/templates/api.yaml
@@ -81,9 +81,9 @@ spec:
           mountPath: /etc/bitwarden/logs
           subPath: api
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
-          mountPath: /etc/bitwarden/ca-certificates
+          mountPath: /etc/bitwarden.ca_certificates
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
@@ -107,10 +107,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
           persistentVolumeClaim:
-            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
+            claimName: {{ default ( include "bitwarden.ca_certificates" . ) .Values.volume.ca_certificates.existingClaim }}
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline

--- a/charts/self-host/templates/api.yaml
+++ b/charts/self-host/templates/api.yaml
@@ -81,6 +81,10 @@ spec:
           mountPath: /etc/bitwarden/logs
           subPath: api
         {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          mountPath: /etc/bitwarden/ca-certificates
+        {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
@@ -102,6 +106,11 @@ spec:
         - name: applogs
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
+        {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          persistentVolumeClaim:
+            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline

--- a/charts/self-host/templates/events.yaml
+++ b/charts/self-host/templates/events.yaml
@@ -75,9 +75,9 @@ spec:
           mountPath: "/mnt/secrets-store"
           readOnly: true
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
-          mountPath: /etc/bitwarden/ca-certificates
+          mountPath: /etc/bitwarden.ca_certificates
         {{- end }}
         {{- if .Values.volume.logs.enabled }}
         - name: applogs
@@ -95,10 +95,10 @@ spec:
             volumeAttributes:
               secretProviderClass: {{ .Values.secrets.secretProviderClass }}
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
           persistentVolumeClaim:
-            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
+            claimName: {{ default ( include "bitwarden.ca_certificates" . ) .Values.volume.ca_certificates.existingClaim }}
         {{- end }}
         {{- if .Values.volume.logs.enabled }}
         - name: applogs

--- a/charts/self-host/templates/events.yaml
+++ b/charts/self-host/templates/events.yaml
@@ -75,6 +75,10 @@ spec:
           mountPath: "/mnt/secrets-store"
           readOnly: true
         {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          mountPath: /etc/bitwarden/ca-certificates
+        {{- end }}
         {{- if .Values.volume.logs.enabled }}
         - name: applogs
           mountPath: /etc/bitwarden/logs
@@ -90,6 +94,11 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ .Values.secrets.secretProviderClass }}
+        {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          persistentVolumeClaim:
+            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
         {{- end }}
         {{- if .Values.volume.logs.enabled }}
         - name: applogs

--- a/charts/self-host/templates/icons.yaml
+++ b/charts/self-host/templates/icons.yaml
@@ -68,9 +68,9 @@ spec:
         ports:
         - containerPort: 5000
         volumeMounts:
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
-          mountPath: /etc/bitwarden/ca-certificates
+          mountPath: /etc/bitwarden.ca_certificates
         {{- end }}
         {{- if .Values.secrets.secretProviderClass}}
         - name: secrets-store-inline
@@ -95,10 +95,10 @@ spec:
             volumeAttributes:
               secretProviderClass: {{ .Values.secrets.secretProviderClass }}
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
           persistentVolumeClaim:
-            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
+            claimName: {{ default ( include "bitwarden.ca_certificates" . ) .Values.volume.ca_certificates.existingClaim }}
         {{- end }}
         {{- if .Values.volume.logs.enabled }}
         - name: applogs

--- a/charts/self-host/templates/icons.yaml
+++ b/charts/self-host/templates/icons.yaml
@@ -68,6 +68,10 @@ spec:
         ports:
         - containerPort: 5000
         volumeMounts:
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          mountPath: /etc/bitwarden/ca-certificates
+        {{- end }}
         {{- if .Values.secrets.secretProviderClass}}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
@@ -90,6 +94,11 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ .Values.secrets.secretProviderClass }}
+        {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          persistentVolumeClaim:
+            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
         {{- end }}
         {{- if .Values.volume.logs.enabled }}
         - name: applogs

--- a/charts/self-host/templates/identity.yaml
+++ b/charts/self-host/templates/identity.yaml
@@ -83,6 +83,10 @@ spec:
           mountPath: /etc/bitwarden/logs
           subPath: identity
         {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          mountPath: /etc/bitwarden/ca-certificates
+        {{- end }}
         {{- if .Values.secrets.secretProviderClass}}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
@@ -104,6 +108,11 @@ spec:
         - name: applogs
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
+        {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          persistentVolumeClaim:
+            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline

--- a/charts/self-host/templates/identity.yaml
+++ b/charts/self-host/templates/identity.yaml
@@ -83,9 +83,9 @@ spec:
           mountPath: /etc/bitwarden/logs
           subPath: identity
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
-          mountPath: /etc/bitwarden/ca-certificates
+          mountPath: /etc/bitwarden.ca_certificates
         {{- end }}
         {{- if .Values.secrets.secretProviderClass}}
         - name: secrets-store-inline
@@ -109,10 +109,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
           persistentVolumeClaim:
-            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
+            claimName: {{ default ( include "bitwarden.ca_certificates" . ) .Values.volume.ca_certificates.existingClaim }}
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline

--- a/charts/self-host/templates/notifications.yaml
+++ b/charts/self-host/templates/notifications.yaml
@@ -80,6 +80,10 @@ spec:
           mountPath: /etc/bitwarden/logs
           subPath: notifications
         {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          mountPath: /etc/bitwarden/ca-certificates
+        {{- end }}
         securityContext:
 {{ toYaml .Values.component.notifications.securityContext | indent 10 }}
       volumes:
@@ -95,6 +99,11 @@ spec:
         - name: applogs
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
+        {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          persistentVolumeClaim:
+            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
         {{- end }}
 
 ---

--- a/charts/self-host/templates/notifications.yaml
+++ b/charts/self-host/templates/notifications.yaml
@@ -80,9 +80,9 @@ spec:
           mountPath: /etc/bitwarden/logs
           subPath: notifications
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
-          mountPath: /etc/bitwarden/ca-certificates
+          mountPath: /etc/bitwarden.ca_certificates
         {{- end }}
         securityContext:
 {{ toYaml .Values.component.notifications.securityContext | indent 10 }}
@@ -100,10 +100,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
           persistentVolumeClaim:
-            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
+            claimName: {{ default ( include "bitwarden.ca_certificates" . ) .Values.volume.ca_certificates.existingClaim }}
         {{- end }}
 
 ---

--- a/charts/self-host/templates/scim.yaml
+++ b/charts/self-host/templates/scim.yaml
@@ -82,9 +82,9 @@ spec:
           mountPath: /etc/bitwarden/logs
           subPath: scim
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
-          mountPath: /etc/bitwarden/ca-certificates
+          mountPath: /etc/bitwarden.ca_certificates
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
@@ -108,10 +108,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
           persistentVolumeClaim:
-            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
+            claimName: {{ default ( include "bitwarden.ca_certificates" . ) .Values.volume.ca_certificates.existingClaim }}
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline

--- a/charts/self-host/templates/scim.yaml
+++ b/charts/self-host/templates/scim.yaml
@@ -82,6 +82,10 @@ spec:
           mountPath: /etc/bitwarden/logs
           subPath: scim
         {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          mountPath: /etc/bitwarden/ca-certificates
+        {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
@@ -103,6 +107,11 @@ spec:
         - name: applogs
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
+        {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          persistentVolumeClaim:
+            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline

--- a/charts/self-host/templates/sso.yaml
+++ b/charts/self-host/templates/sso.yaml
@@ -83,9 +83,9 @@ spec:
           mountPath: /etc/bitwarden/logs
           subPath: sso
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
-          mountPath: /etc/bitwarden/ca-certificates
+          mountPath: /etc/bitwarden.ca_certificates
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
@@ -109,10 +109,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
         {{- end }}
-        {{- if .Values.volume.ca-certificates.enabled }}
+        {{- if .Values.volume.ca_certificates.enabled }}
         - name: ca-certificates
           persistentVolumeClaim:
-            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
+            claimName: {{ default ( include "bitwarden.ca_certificates" . ) .Values.volume.ca_certificates.existingClaim }}
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline

--- a/charts/self-host/templates/sso.yaml
+++ b/charts/self-host/templates/sso.yaml
@@ -83,6 +83,10 @@ spec:
           mountPath: /etc/bitwarden/logs
           subPath: sso
         {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          mountPath: /etc/bitwarden/ca-certificates
+        {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
@@ -104,6 +108,11 @@ spec:
         - name: applogs
           persistentVolumeClaim:
             claimName: {{ default ( include "bitwarden.applogs" . ) .Values.volume.logs.existingClaim }}
+        {{- end }}
+        {{- if .Values.volume.ca-certificates.enabled }}
+        - name: ca-certificates
+          persistentVolumeClaim:
+            claimName: {{ default ( include "bitwarden.ca-certificates" . ) .Values.volume.ca-certificates.existingClaim }}
         {{- end }}
         {{- if .Values.secrets.secretProviderClass }}
         - name: secrets-store-inline

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -351,7 +351,7 @@ volume:
     # storageClass: "shared-storage"
     size: 1Gi
     labels: {}
-  ca-certificates:
+  ca_certificates:
     # Extra root certificates are disabled by default
     enabled: false
     # Use an existing PVC by specifying the name.

--- a/charts/self-host/values.yaml
+++ b/charts/self-host/values.yaml
@@ -351,6 +351,17 @@ volume:
     # storageClass: "shared-storage"
     size: 1Gi
     labels: {}
+  ca-certificates:
+    # Extra root certificates are disabled by default
+    enabled: false
+    # Use an existing PVC by specifying the name.
+    # existingClaim: claimName
+    # Override the accessMode specified in general.volumeAccessMode
+    # accessMode: ReadWriteOnce
+    # Override the storageClass specified in sharedStorageClassName
+    # storageClass: "shared-storage"
+    size: 1Gi
+    labels: {}
 
 #
 # Configure service account for pre- and post-install hooks


### PR DESCRIPTION
When connecting to internal SMTP servers, OIDC SSO endpoints, or through forward proxies, it may be necessary to load custom root trust into the deployed Bitwarden installation. This - should! - allow for a persistent volume to store this data.